### PR TITLE
Add fromResources to AuthorizationConfiguration

### DIFF
--- a/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
+++ b/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
@@ -50,11 +50,7 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         AuthorizationManager.initialize(
-            AuthorizationConfiguration(
-                clientId = "21e13847-4f30-4477-a2d9-33c3a80bd15a",
-                fusionAuthUrl = "http://10.168.145.33:9011",
-                allowUnsecureConnection = true
-            ),
+            AuthorizationConfiguration.fromResources(this, R.raw.fusionauth_config),
             SharedPreferencesStorage(this)
         )
 

--- a/app/src/main/java/io/fusionauth/sdk/TokenActivity.kt
+++ b/app/src/main/java/io/fusionauth/sdk/TokenActivity.kt
@@ -57,11 +57,7 @@ class TokenActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         AuthorizationManager.initialize(
-            AuthorizationConfiguration(
-                clientId = "21e13847-4f30-4477-a2d9-33c3a80bd15a",
-                fusionAuthUrl = "http://10.168.145.33:9011",
-                allowUnsecureConnection = true
-            ),
+            AuthorizationConfiguration.fromResources(this, R.raw.fusionauth_config),
             SharedPreferencesStorage(this)
         )
 

--- a/app/src/main/res/raw/fusionauth_config.json
+++ b/app/src/main/res/raw/fusionauth_config.json
@@ -1,4 +1,5 @@
 {
-  "fusionAuthUrl": "http://10.168.145.33:9011",
-  "clientId": "21e13847-4f30-4477-a2d9-33c3a80bd15a"
+  "fusionAuthUrl": "http://10.0.2.2:9011",
+  "clientId": "21e13847-4f30-4477-a2d9-33c3a80bd15a",
+  "allowUnsecureConnection": true
 }

--- a/library/src/main/java/io/fusionauth/mobilesdk/AuthorizationConfiguration.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/AuthorizationConfiguration.kt
@@ -1,5 +1,6 @@
 package io.fusionauth.mobilesdk
 
+import android.content.Context
 import kotlinx.serialization.Serializable
 import java.util.logging.Logger
 
@@ -32,5 +33,21 @@ data class AuthorizationConfiguration(
 
     fun withAdditionalScopes(scopes: Set<String>): AuthorizationConfiguration {
         return this.copy(additionalScopes = scopes)
+    }
+
+    companion object {
+
+        /**
+         * Reads a JSON file from resources and converts it into an AuthorizationConfiguration object.
+         *
+         * @param context The context used to access resources.
+         * @param resource The resource ID of the JSON file.
+         * @return The AuthorizationConfiguration object created from the JSON file.
+         */
+        fun fromResources(context: Context, resource: Int): AuthorizationConfiguration {
+            val json = context.resources.openRawResource(resource).bufferedReader().use { it.readText() }
+            return kotlinx.serialization.json.Json.decodeFromString(json)
+        }
+
     }
 }


### PR DESCRIPTION
The method `fromResources` is added to the AuthorizationConfiguration class, which reads a JSON file from Android resources and converts it into an AuthorizationConfiguration object.

The initialization of AuthorizationManager in LoginActivity and TokenActivity is updated to use this new method. The fusionauth_config.json file, which contains the configuration data, is also updated with the default host IP in the Android emulator environment.