### PR TITLE
Add Device Authorization Grant

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("androidx.browser:browser:1.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("com.journeyapps:zxing-android-embedded:4.1.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,32 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+          xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name_short"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:usesCleartextTraffic="true"
-        tools:targetApi="31">
+            android:allowBackup="true"
+            android:dataExtractionRules="@xml/data_extraction_rules"
+            android:fullBackupContent="@xml/backup_rules"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name_short"
+            android:roundIcon="@mipmap/ic_launcher_round"
+            android:supportsRtl="true"
+            android:theme="@style/AppTheme"
+            android:usesCleartextTraffic="true"
+            tools:targetApi="31">
         <activity
-            android:name=".LoginActivity"
-            android:exported="true">
+                android:name=".DeviceLoginActivity"
+                android:exported="false"/>
+        <activity
+                android:name=".LoginActivity"
+                android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-
-        <activity android:name=".TokenActivity"
-                  android:windowSoftInputMode="stateHidden" />
+        <activity
+                android:name=".TokenActivity"
+                android:windowSoftInputMode="stateHidden"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/fusionauth/sdk/DeviceLoginActivity.kt
+++ b/app/src/main/java/io/fusionauth/sdk/DeviceLoginActivity.kt
@@ -1,0 +1,120 @@
+package io.fusionauth.sdk
+
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.MainThread
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.zxing.BarcodeFormat
+import com.journeyapps.barcodescanner.BarcodeEncoder
+import io.fusionauth.mobilesdk.AuthorizationManager
+import io.fusionauth.mobilesdk.ExperimentalApi
+import io.fusionauth.mobilesdk.exceptions.AuthorizationException
+import kotlinx.coroutines.launch
+
+/**
+ * Demonstrates the usage of the FusionAuth SDK to authorize a user utilizing the Device Authorization
+ * Grant. This is useful for devices that do not have a browser or other input mechanism.
+ */
+class DeviceLoginActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(R.layout.activity_device_login)
+
+        findViewById<View>(R.id.device_login).setOnClickListener {
+            startAuth()
+        }
+
+        displayAuthOptions()
+    }
+
+    @OptIn(ExperimentalApi::class)
+    @MainThread
+    fun startAuth() {
+        displayLoading("Starting device authorization request")
+
+        lifecycleScope.launch {
+            try {
+                val deviceCodeResponse = AuthorizationManager
+                    .oAuth(this@DeviceLoginActivity)
+                    .deviceAuthorize()
+
+                findViewById<TextView>(R.id.device_code_code).let {
+                    (it as TextView).text = deviceCodeResponse.user_code
+                }
+                findViewById<TextView>(R.id.device_code_link).let {
+                    (it as TextView).text = deviceCodeResponse.verification_uri
+                }
+
+                BarcodeEncoder().encodeBitmap(
+                    deviceCodeResponse.verification_uri_complete,
+                    BarcodeFormat.QR_CODE,
+                    QR_CODE_DIMENSION, QR_CODE_DIMENSION
+                )
+                    .let { bitmap ->
+                        findViewById<ImageView>(R.id.device_code_qr).setImageBitmap(bitmap)
+                    }
+
+                displayDeviceCode()
+
+                displayLoading("Polling for authorization")
+
+                val authState = AuthorizationManager
+                    .oAuth(this@DeviceLoginActivity)
+                    .getDeviceFusionAuthState(deviceCodeResponse)
+
+                // Is logged in!
+                startActivity(Intent(this@DeviceLoginActivity, TokenActivity::class.java))
+            } catch (e: AuthorizationException) {
+                Log.e(DeviceLoginActivity.TAG, "Error while authorizing", e)
+                displayError(e.message ?: "Error while authorizing", true)
+            }
+        }
+    }
+
+    @MainThread
+    private fun displayLoading(loadingMessage: String) {
+        findViewById<View>(R.id.loading_container).visibility = View.VISIBLE
+        findViewById<View>(R.id.auth_container).visibility = View.GONE
+        findViewById<View>(R.id.error_container).visibility = View.GONE
+
+        (findViewById<View>(R.id.loading_description) as TextView).text = loadingMessage
+    }
+
+    @MainThread
+    private fun displayError(error: String, recoverable: Boolean) {
+        findViewById<View>(R.id.error_container).visibility = View.VISIBLE
+        findViewById<View>(R.id.loading_container).visibility = View.GONE
+        findViewById<View>(R.id.auth_container).visibility = View.GONE
+
+        (findViewById<View>(R.id.error_description) as TextView).text = error
+        findViewById<View>(R.id.retry).visibility = if (recoverable) View.VISIBLE else View.GONE
+    }
+
+    @MainThread
+    private fun displayAuthOptions() {
+        findViewById<View>(R.id.device_code_container).visibility = View.GONE
+        findViewById<View>(R.id.auth_container).visibility = View.VISIBLE
+        findViewById<View>(R.id.loading_container).visibility = View.GONE
+        findViewById<View>(R.id.error_container).visibility = View.GONE
+    }
+
+    @MainThread
+    private fun displayDeviceCode() {
+        findViewById<View>(R.id.device_code_container).visibility = View.VISIBLE
+        findViewById<View>(R.id.auth_container).visibility = View.GONE
+        findViewById<View>(R.id.loading_container).visibility = View.GONE
+        findViewById<View>(R.id.error_container).visibility = View.GONE
+    }
+
+    companion object {
+        private const val TAG = "DeviceLoginActivity"
+        private const val QR_CODE_DIMENSION = 512
+    }
+
+}

--- a/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
+++ b/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
@@ -24,8 +24,8 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import io.fusionauth.mobilesdk.AuthorizationConfiguration
 import io.fusionauth.mobilesdk.AuthorizationManager
-import io.fusionauth.mobilesdk.oauth.OAuthAuthorizeOptions
 import io.fusionauth.mobilesdk.exceptions.AuthorizationException
+import io.fusionauth.mobilesdk.oauth.OAuthAuthorizeOptions
 import io.fusionauth.mobilesdk.storage.SharedPreferencesStorage
 import kotlinx.coroutines.launch
 
@@ -68,6 +68,9 @@ class LoginActivity : AppCompatActivity() {
         }
         findViewById<View>(R.id.start_auth).setOnClickListener {
             startAuth()
+        }
+        findViewById<View>(R.id.device_login).setOnClickListener {
+            startActivity(Intent(this, DeviceLoginActivity::class.java))
         }
 
         if (AuthorizationManager.oAuth(this@LoginActivity).isCancelled(intent)) {

--- a/app/src/main/res/layout/activity_device_login.xml
+++ b/app/src/main/res/layout/activity_device_login.xml
@@ -3,7 +3,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
-        tools:context=".LoginActivity"
+        tools:context=".DeviceLoginActivity"
         android:id="@+id/coordinator"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -93,14 +93,6 @@
                     android:orientation="horizontal" android:gravity="center">
 
                 <Button
-                        android:id="@+id/start_auth"
-                        style="@style/Widget.AppCompat.Button.Colored"
-                        android:text="@string/start_authorization"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"/>
-
-                <Button
                         android:id="@+id/device_login"
                         style="@style/Widget.AppCompat.Button.Colored"
                         android:text="@string/device_login"
@@ -108,6 +100,83 @@
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"/>
 
+            </LinearLayout>
+
+            <LinearLayout
+                    android:id="@+id/device_code_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_marginTop="@dimen/section_margin"
+                    android:layout_marginBottom="8dp"
+                    android:orientation="vertical" android:gravity="center">
+
+                <TextView
+                        android:id="@+id/device_code_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_margin"
+                        android:layout_marginBottom="8dp"
+                        android:layout_gravity="center"
+                        android:text="@string/device_code_title"
+                        style="@style/Base.TextAppearance.AppCompat.Title"
+                        android:textColor="@color/colorAccent"/>
+
+                <TextView
+                        android:id="@+id/device_code_description"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_margin"
+                        android:layout_marginBottom="8dp"
+                        android:layout_gravity="center"
+                        android:text="@string/device_code_description"
+                        style="@style/Base.TextAppearance.AppCompat.Body1"/>
+
+                <TextView
+                        android:id="@+id/device_code_link"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_margin"
+                        android:layout_marginBottom="8dp"
+                        android:layout_gravity="center"
+                        style="@style/Base.TextAppearance.AppCompat.Title"
+                        android:textColor="@color/colorAccent"/>
+
+                <TextView
+                        android:id="@+id/device_code_code"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_margin"
+                        android:layout_marginBottom="8dp"
+                        android:layout_gravity="center"
+                        style="@style/Base.TextAppearance.AppCompat.Title"
+                        android:textColor="@color/colorAccent"/>
+
+                <View
+                        android:layout_width="match_parent"
+                        android:layout_height="2dp"
+                        android:background="@color/colorPrimary"/>
+
+                <TextView
+                        android:id="@+id/device_code_qr_description"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/section_margin"
+                        android:layout_marginBottom="8dp"
+                        android:layout_gravity="center"
+                        android:text="@string/device_code_qr_description"
+                        style="@style/Base.TextAppearance.AppCompat.Body1"/>
+
+                <ImageView
+                        android:id="@+id/device_code_qr"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="32dp"
+                        android:layout_marginTop="100dp"
+                        android:layout_marginEnd="32dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/device_login"
+                        android:contentDescription="@string/qr_code_with_link_to_user_code_login"/>
 
             </LinearLayout>
 
@@ -137,4 +206,5 @@
             </LinearLayout>
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,11 @@
     <string name="change_text_input_placeholder">0.00</string>
     <string name="change_button">Make change</string>
     <string name="change_result_text_view">We can make change for %1$s with %2$d nickels and %3$d pennies!</string>
+    <string name="device_login">Device Login</string>
+    <string name="qr_code_with_link_to_user_code_login">QR Code with link to user code login</string>
+    <string name="device_code_title">Sign in to activate your device</string>
+    <string name="device_code_description">To complete activation, navigate to the following site and enter the
+        following activation code:
+    </string>
+    <string name="device_code_qr_description">Or scan the QR code below to log in.</string>
 </resources>

--- a/library/src/main/java/io/fusionauth/mobilesdk/ExperimentalApi.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/ExperimentalApi.kt
@@ -1,0 +1,12 @@
+package io.fusionauth.mobilesdk
+
+/**
+ * Marks the API as experimental and may be subject to change in the future.
+ */
+@RequiresOptIn(
+    message = "This API is experimental and may be subject to change in the future.",
+    level = RequiresOptIn.Level.WARNING
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class ExperimentalApi

--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthDeviceAuthorizationResponse.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthDeviceAuthorizationResponse.kt
@@ -1,0 +1,17 @@
+package io.fusionauth.mobilesdk.oauth
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the device authorization response retrieved from FusionAuth.
+ */
+@Suppress("PropertyName", "ConstructorParameterNaming")
+@Serializable
+data class OAuthDeviceAuthorizationResponse (
+    val device_code: String,
+    val expires_in: Long,
+    val interval: Long,
+    val user_code: String,
+    val verification_uri: String,
+    val verification_uri_complete: String,
+)

--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthErrorResponse.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthErrorResponse.kt
@@ -1,0 +1,20 @@
+package io.fusionauth.mobilesdk.oauth
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents an OAuth error response.
+ *
+ * @property error The error code.
+ * @property error_description A human-readable description of the error.
+ * @property error_reason The reason for the error, if available.
+ * @property state The state parameter, if provided in the request.
+ */
+@Suppress("PropertyName", "ConstructorParameterNaming")
+@Serializable
+data class OAuthErrorResponse(
+    val error: String,
+    val error_description: String,
+    val error_reason: String? = null,
+    val state: String? = null
+)

--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthTokenResponse.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthTokenResponse.kt
@@ -1,0 +1,30 @@
+package io.fusionauth.mobilesdk.oauth
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the response received from the OAuth token request.
+ *
+ * See [FusionAuth OAuth Endpoints](https://fusionauth.io/docs/lifecycle/authenticate-users/oauth/endpoints#response-3)
+ *
+ * @property access_token The access token.
+ * @property expires_in The expiration time of the access token in seconds.
+ * @property id_token The ID token.
+ * @property refresh_token The refresh token.
+ * @property refresh_token_id The ID of the refresh token.
+ * @property scope The scope of the access token.
+ * @property token_type The token type as defined by RFC 6749 Section 7.1. This value will always be Bearer.
+ * @property userId The unique Id of the user that has been authenticated.
+ */
+@Suppress("PropertyName", "ConstructorParameterNaming")
+@Serializable
+data class OAuthTokenResponse(
+    val access_token: String,
+    val expires_in: Long,
+    val id_token: String,
+    val refresh_token: String,
+    val refresh_token_id: String,
+    val scope: String,
+    val token_type: String,
+    val userId: String,
+)


### PR DESCRIPTION
Adds the Device Authorization Grant.

Current workflow:
1. Use `deviceAuthorize()` to start the Device Authorization Flow
2. Display verification link and user code, or QR code with full verification link in the app
3. Call `getDeviceFusionAuthState()`, this starts a Flow that polls the back end until the user has logged-in using the verification link and user code, or the link has expired
4. Finally, verify logged in status and navigate to Activity

Things that are not yet implemented
- [ ] Make flow / polling cancellable
- [ ] Improve retry mechanism

Because this is not covered by AppAuth implementation, I've marked it with an ExperimentalApi decorator.

Related PR on AppAuth openid/AppAuth-Android#763