### PR TITLE
fix: set additional scopes and make email_verified optional

### DIFF
--- a/app/src/main/res/raw/fusionauth_config.json
+++ b/app/src/main/res/raw/fusionauth_config.json
@@ -1,5 +1,6 @@
 {
   "fusionAuthUrl": "http://10.0.2.2:9011",
   "clientId": "21e13847-4f30-4477-a2d9-33c3a80bd15a",
-  "allowUnsecureConnection": true
+  "allowUnsecureConnection": true,
+  "additionalScopes": ["email", "profile"]
 }

--- a/library/src/main/java/io/fusionauth/mobilesdk/UserInfo.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/UserInfo.kt
@@ -27,7 +27,7 @@ data class UserInfo(
     val applicationId: String? = null,
     val birthdate: String? = null,
     val email: String? = null,
-    val email_verified: Boolean,
+    val email_verified: Boolean? = null,
     val family_name: String? = null,
     val given_name: String? = null,
     val name: String? = null,


### PR DESCRIPTION
FusionAuth 1.50.0 introduced the Scope Handling Policy. In new installation it's set to `scopeHandlingPolicy.Strict`, which causes previously available fields to not be included in the response.

The fusionauth_config.json was updated to include the additional scopes `email` and `profile`.

In the `UserInfo` class, the required field `email_verified` was made optional, providing a null default value to prevent issues when this field is not provided.

Closes #62