### PR TITLE
build(deps): bump gradle-major-dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.9.20"
 
     kotlin("jvm") version "1.9.24"
-    kotlin("plugin.serialization") version "1.9.24"
+    kotlin("plugin.serialization") version "2.0.0"
 }
 
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {


### PR DESCRIPTION
build(deps): bump jvm from 1.9.24 to 2.0.0 #72 
build(deps): bump plugin.serialization from 1.9.24 to 2.0.0 #71 
build(deps): bump org.jetbrains.kotlin.android from 1.9.24 to 2.0.0 #70