### PR TITLE
fix(oauth): update handleRedirect exception handling

### DIFF
--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
@@ -105,7 +105,6 @@ class OAuthAuthorizationService internal constructor(
             0,
             Intent(completedIntent).also {
                 replaceExtras(it, Bundle().also { bundle ->
-                    if (options?.state != null) bundle.putString(EXTRA_STATE, options.state)
                     bundle.putBoolean(EXTRA_AUTHORIZED, true)
                 })
             },
@@ -175,12 +174,6 @@ class OAuthAuthorizationService internal constructor(
             if (exception != null) {
                 appAuthState.update(response, exception)
                 throw AuthorizationException(exception)
-            }
-
-            // Validate the state
-            val state = intent.getStringExtra(EXTRA_STATE)
-            if (state.orEmpty() != response?.state.orEmpty()) {
-                throw AuthorizationException("State mismatch")
             }
 
             appAuthState.update(response, null)
@@ -294,7 +287,6 @@ class OAuthAuthorizationService internal constructor(
             0,
             Intent(completedIntent).also {
                 replaceExtras(it, Bundle().also { bundle ->
-                    if (options?.state != null) bundle.putString(EXTRA_STATE, options.state)
                     bundle.putBoolean(EXTRA_LOGGED_OUT, true)
                 })
             },
@@ -559,12 +551,11 @@ class OAuthAuthorizationService internal constructor(
             AtomicReference(null)
         private val json = Json { ignoreUnknownKeys = true }
 
-        private const val EXTRA_STATE: String = "io.fusionauth.mobilesdk.state"
         const val EXTRA_CANCELLED: String = "io.fusionauth.mobilesdk.cancelled"
         const val EXTRA_AUTHORIZED: String = "io.fusionauth.mobilesdk.logged_in"
         const val EXTRA_LOGGED_OUT: String = "io.fusionauth.mobilesdk.logged_out"
 
-        private val EXTRAS = setOf(EXTRA_STATE, EXTRA_CANCELLED, EXTRA_AUTHORIZED, EXTRA_LOGGED_OUT)
+        private val EXTRAS = setOf(EXTRA_CANCELLED, EXTRA_AUTHORIZED, EXTRA_LOGGED_OUT)
     }
 
 }

--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
@@ -153,9 +153,7 @@ class OAuthAuthorizationService internal constructor(
 
         // Authorize Options
         options?.codeChallenge?.let { additionalParameters["code_challenge"] = it }
-        options?.codeChallengeMethod?.let {
-            additionalParameters["code_challenge_method"] = it.name
-        }
+        options?.codeChallengeMethod?.let { additionalParameters["code_challenge_method"] = it.name }
         options?.idpHint?.let { additionalParameters["idp_hint"] = it }
         options?.deviceDescription?.let { additionalParameters["metaData.device.description"] = it }
         options?.userCode?.let { additionalParameters["user_code"] = it }
@@ -244,8 +242,7 @@ class OAuthAuthorizationService internal constructor(
     suspend fun getUserInfo(): UserInfo? {
         return withContext(defaultDispatcher) {
             val config = getConfiguration()
-            val accessToken =
-                AuthorizationManager.freshAccessToken(context) ?: return@withContext null
+            val accessToken = AuthorizationManager.freshAccessToken(context) ?: return@withContext null
 
             val conn: HttpURLConnection = config.discoveryDoc?.userinfoEndpoint.let {
                 if (it == null) {
@@ -287,11 +284,7 @@ class OAuthAuthorizationService internal constructor(
             config
         )
             .setIdTokenHint(authState.idToken)
-            .setPostLogoutRedirectUri(
-                Uri.parse(
-                    options?.postLogoutRedirectUri ?: "io.fusionauth.app:/oauth2redirect"
-                )
-            )
+            .setPostLogoutRedirectUri(Uri.parse(options?.postLogoutRedirectUri ?: "io.fusionauth.app:/oauth2redirect"))
             .setAdditionalParameters(additionalParameters)
 
         options?.state?.let { logoutRequestBuilder.setState(it) }
@@ -561,8 +554,7 @@ class OAuthAuthorizationService internal constructor(
     }
 
     companion object {
-        private val deferredTokenRefreshRef: AtomicReference<Deferred<String?>?> =
-            AtomicReference(null)
+        private val deferredTokenRefreshRef: AtomicReference<Deferred<String?>?> = AtomicReference(null)
         private val deferredFetchConfigurationRef: AtomicReference<Deferred<AuthorizationServiceConfiguration>?> =
             AtomicReference(null)
         private val json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
Handle any exception from the AuthorizationRequest before trying to validate the state.

Also remove the manual state validation. This should be handled by AppAuth

Closes #64