### PR TITLE
refactor: simplify issuer scheme validation by removing unnecessary try-catch

### DIFF
--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
@@ -404,11 +404,7 @@ class OAuthAuthorizationService internal constructor(
                         // Otherwise we get a NullPointerException, when trying to validate the id token later
 
                         val issuerScheme = configuration.discoveryDoc?.issuer?.let {
-                            try {
-                                Uri.parse(it).scheme
-                            } catch (e: Exception) {
-                                null
-                            }
+                            Uri.parse(it).scheme
                         }
                         if (issuerScheme != "https" && issuerScheme != "http") {
                             continuation.resumeWithException(AuthorizationException("Invalid issuer URL"))


### PR DESCRIPTION
The try-catch is not necessary, because only NullPointerException should be thrown when passing `null` to `Uri.parse`, and that is already catched by `?.let`