### PR TITLE
fix(release): add missed detekt pre-check and workflow_call

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,8 @@ on:
     - cron: '39 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -27,6 +27,8 @@ on:
      - cron: '25 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
@@ -14,6 +14,8 @@ on:
     - cron: '20 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 env:
   fusionauth-docker-image-version: "latest"

--- a/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
@@ -14,6 +14,8 @@ on:
     branches: [ "main" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 env:
   fusionauth-docker-image-version: "1.55.1"

--- a/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
@@ -15,7 +15,7 @@ name: E2E Test with FusionAuth supported versions
 on:
   # To allow running this workflow manually from the Actions tab we add:
   workflow_dispatch:
-  # Triggers the workflow on push request events but only for tag versions
+  # Triggers the workflow on call from another workflow
   workflow_call:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ on:
     branches: [ "main" ]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -14,6 +14,8 @@ on:
     - cron: '30 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  # Triggers the workflow on call from another workflow
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,32 +48,37 @@ jobs:
           gh label create "autorelease: snapshot" -c D4C5F9 -d "release-please PR tagging - Ready for release" || true
           gh label create "autorelease: published" -c 0E8A16 -d "release-please PR tagging - Released" || true
 
+  # This job runs a CodeQL scan as a prerequisite for the prerelease-prep
+  codeql:
+    name: Run Prerelease CodeQL Package Scan
+    uses: ./.github/workflows/codeql.yml
+
+  # This job runs a detekt scan as a prerequisite for the prerelease-prep
+  detekt:
+    name: Run Prerelease CodeQL Package Scan
+    uses: ./.github/workflows/detekt.yml
+
   # This job runs a simple E2E test with the latest FusionAuth and iOS version as a prerequisite for the prerelease-prep
   initial-e2e-test:
     name: Run Prerelease E2E Tests
     uses: ./.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
-
-  # This job runs a MobSF scan as a prerequisite for the prerelease-prep
-  mobsf:
-    name: Run Prerelease MobSF Scan
-    uses: ./.github/workflows/mobsf.yml
 
   # This job runs a Lint scan as a prerequisite for the prerelease-prep
   lint:
     name: Run Prerelease Lint
     uses: ./.github/workflows/lint.yml
 
-  # This job runs a CodeQL scan as a prerequisite for the prerelease-prep
-  codeql:
-    name: Run Prerelease CodeQL Package Scan
-    uses: ./.github/workflows/codeql.yml
+  # This job runs a MobSF scan as a prerequisite for the prerelease-prep
+  mobsf:
+    name: Run Prerelease MobSF Scan
+    uses: ./.github/workflows/mobsf.yml
 
   # This job creates or finalizes a prerelease pull request or finalizes a release pull request
   # and provides the necessary outputs for the subsequent jobs
   prerelease-prep:
     name: Create Prerelease Pull Request
     runs-on: ubuntu-latest
-    needs: [ label-check, initial-e2e-test, mobsf, lint, codeql ]
+    needs: [ label-check, codeql, detekt, initial-e2e-test, lint, mobsf ]
     outputs:
       # This output is used to determine if a release was created
       releases_created: ${{ steps.release.outputs.releases_created }}


### PR DESCRIPTION
- The detekt workflow was not added as a dependency to the release workflow
- The workflow_call is required in each workflow in order for release workflow to execute the individual workflows