### PR TITLE
docs(README): fix code highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ tag::forDocSiteGettingStarted[]
 -->
 To use the FusionAuth Android SDK, add the following dependency to your `build.gradle` file:
 
-```dsl
+```kotlin
 dependencies {
     implementation('io.fusionauth:fusionauth-android-sdk:<latest-version>')
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ end::forDocSiteOverview[]
 <!--
 tag::forDocSiteGettingStarted[]
 -->
-To use the FusionAuth Android SDK, add the following dependency to your `build.gradle` file:
+To use the FusionAuth Android SDK, add the following dependency to your `build.gradle.kts` file:
 
 ```kotlin
 dependencies {


### PR DESCRIPTION
dsl is not a valid language for highlighting, this is causing issues when building the sites depending on this readme.