### PR TITLE
ci(release): switch to user token

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,8 +12,6 @@
 name: Vulnerability Scan with CodeQL
 
 on:
-  push:
-    branches: [ "main", "release-please--branches--main"]
   pull_request:
     branches: [ "main" ]
   schedule:
@@ -51,44 +49,44 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    - name: Setup JDK 17
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: '17'
-        distribution: 'zulu'
-    
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3.28.11
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'zulu'
 
-        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        queries: security-and-quality
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3.28.11
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          queries: security-and-quality
 
 
-    # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3.28.11
+      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3.28.11
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    # - run: |
-    #     echo "Run, Build Application using script"
-    #     ./location_of_script_within_repo/buildscript.sh
+      # - run: |
+      #     echo "Run, Build Application using script"
+      #     ./location_of_script_within_repo/buildscript.sh
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3.28.11
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3.28.11
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -18,13 +18,10 @@
 name: Vulnerability Scan with Detekt
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
-  push:
-    branches: [ "main", "release-please--branches--main"]
   pull_request:
     branches: [ "main" ]
   schedule:
-     - cron: '25 6 * * 1'
+    - cron: '25 6 * * 1'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
   # Triggers the workflow on call from another workflow
@@ -48,44 +45,44 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Sets up JDK as a prerequisite to run Gradle
-    - name: Setup Java
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: '17'
-        distribution: 'zulu'
+      # Sets up JDK as a prerequisite to run Gradle
+      - name: Setup Java
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'zulu'
 
-    # Sets up the reviewdog cli
-    - name: Setup reviewdog
-      uses: reviewdog/action-setup@v1.3.0
+      # Sets up the reviewdog cli
+      - name: Setup reviewdog
+        uses: reviewdog/action-setup@v1.3.0
 
-    - name: Show reviewdog version
-      run: reviewdog -version
+      - name: Show reviewdog version
+        run: reviewdog -version
 
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    # Sets up Gradle as a prerequisite to run Detekt
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.3.0
-      with:
-        gradle-home-cache-cleanup: true
+      # Sets up Gradle as a prerequisite to run Detekt
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4.3.0
+        with:
+          gradle-home-cache-cleanup: true
 
-    # Performs analysis using Detekt via Gradle and outputs a Sarif Report
-    - name: Run Detekt
-      run: ./gradlew detektRelease detektTest detektReportMergeSarif --continue
+      # Performs analysis using Detekt via Gradle and outputs a Sarif Report
+      - name: Run Detekt
+        run: ./gradlew detektRelease detektTest detektReportMergeSarif --continue
 
-    # Uploads Sarif Report to GitHub
-    - name: Upload SARIF to GitHub
-      uses: github/codeql-action/upload-sarif@v3.28.11
-      if: success() || failure()
-      with:
-        sarif_file: build/reports/detekt/merge.sarif.json
+      # Uploads Sarif Report to GitHub
+      - name: Upload SARIF to GitHub
+        uses: github/codeql-action/upload-sarif@v3.28.11
+        if: success() || failure()
+        with:
+          sarif_file: build/reports/detekt/merge.sarif.json
 
-    # Process Sarif Report file from Detekt with reviewdog cli
-    - name: Run reviewdog
-      if: success() || failure()
-      env:
-        REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: reviewdog -f=sarif -diff="git diff FETCH_HEAD" -name="detekt" -reporter=github-pr-check < build/reports/detekt/merge.sarif.json
+      # Process Sarif Report file from Detekt with reviewdog cli
+      - name: Run reviewdog
+        if: success() || failure()
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: reviewdog -f=sarif -diff="git diff FETCH_HEAD" -name="detekt" -reporter=github-pr-check < build/reports/detekt/merge.sarif.json

--- a/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
@@ -9,9 +9,6 @@
 name: E2E Test with latest FusionAuth
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
-  push:
-    branches: [ "release-please--branches--main"]
   # Triggers the workflow on pull request events but only for default and protected branches
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,6 @@
 name: Check Code Quality with Android Lint
 
 on:
-  # Triggers the workflow on push or pull request events but only for default and protected branches
-  push:
-    branches: [ "main", "release-please--branches--main"]
   pull_request:
     branches: [ "main" ]
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -6,8 +6,6 @@
 name: Vulnerability Scan with MobSF
 
 on:
-  push:
-    branches: [ "main", "release-please--branches--main"]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/prerelease-publish-local.yml
+++ b/.github/workflows/prerelease-publish-local.yml
@@ -37,26 +37,26 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Sets up JDK as a prerequisite to run Gradle
-    - name: Setup Java
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: '17'
-        distribution: 'zulu'
+      # Sets up JDK as a prerequisite to run Gradle
+      - name: Setup Java
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'zulu'
 
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    # Sets up Gradle as a prerequisite to run Maven Pre-Release
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.3.0
-      with:
-        gradle-home-cache-cleanup: true
+      # Sets up Gradle as a prerequisite to run Maven Pre-Release
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4.3.0
+        with:
+          gradle-home-cache-cleanup: true
 
-    # Performs a Local Maven Pre-Release
-    - name: Run Maven Local Pre-Release
-      env:
-        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      run: ./gradlew publishReleasePublicationToMavenLocal
+      # Performs a Local Maven Pre-Release
+      - name: Run Maven Local Pre-Release
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+        run: ./gradlew publishReleasePublicationToMavenLocal

--- a/.github/workflows/release-publish-ossrh.yml
+++ b/.github/workflows/release-publish-ossrh.yml
@@ -48,50 +48,50 @@ jobs:
     runs-on: ubuntu-latest
 
     # Requires the staging_profile_id and e2e-test job
-    needs: [create_staging_repository,e2e-test]
+    needs: [ create_staging_repository,e2e-test ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Sets up JDK as a prerequisite to run Gradle
-    - name: Setup Java
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: '17'
-        distribution: 'zulu'
+      # Sets up JDK as a prerequisite to run Gradle
+      - name: Setup Java
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'zulu'
 
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Checkout repository
-      uses: actions/checkout@v4.2.2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
 
-    # Sets up Gradle as a prerequisite to run Maven Release
-    - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4.3.0
-      with:
-        gradle-home-cache-cleanup: true
+      # Sets up Gradle as a prerequisite to run Maven Release
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4.3.0
+        with:
+          gradle-home-cache-cleanup: true
 
-    # Performs a Local Maven Release
-    - name: Run Maven Local Release
-      env:
-        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      run: ./gradlew publishReleasePublicationToMavenLocal
+      # Performs a Local Maven Release
+      - name: Run Maven Local Release
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+        run: ./gradlew publishReleasePublicationToMavenLocal
 
-    # Performs a Maven Release to oss.sonatype.org
-    - name: Run Maven Release to OSSRH
-      env:
-        ossrhUsername: ${{ secrets.NXRM_TOKEN_USERNAME }}
-        ossrhPassword: ${{ secrets.NXRM_TOKEN_PASSWORD }}
-        ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NXRM_TOKEN_USERNAME }}
-        ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NXRM_TOKEN_PASSWORD }}
-        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-        SONATYPE_REPOSITORY_ID: ${{ needs.create_staging_repository.outputs.repository_id }}
-      run: ./gradlew clean publishReleasePublicationToOSSRHRepository
+      # Performs a Maven Release to oss.sonatype.org
+      - name: Run Maven Release to OSSRH
+        env:
+          ossrhUsername: ${{ secrets.NXRM_TOKEN_USERNAME }}
+          ossrhPassword: ${{ secrets.NXRM_TOKEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NXRM_TOKEN_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NXRM_TOKEN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          SONATYPE_REPOSITORY_ID: ${{ needs.create_staging_repository.outputs.repository_id }}
+        run: ./gradlew clean publishReleasePublicationToOSSRHRepository
 
   # The finalize job checks for the success for failure of previous jobs and then either discards or releases the published build
   finalize:
     runs-on: ubuntu-latest
-    needs: [create_staging_repository,publish,e2e-test]
+    needs: [ create_staging_repository,publish,e2e-test ]
     if: ${{ always() && needs.create_staging_repository.result == 'success' }}
     steps:
       - name: Discard

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           config-file: ".github/prerelease-config.json"
           manifest-file: ".github/prerelease-manifest.json"
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
 
   # This job runs tests before the creation of the prerelease
   prerelease-test:
@@ -107,6 +108,7 @@ jobs:
         with:
           config-file: ".github/release-config.json"
           manifest-file: ".github/release-manifest.json"
+          token: ${{ secrets.RELEASE_WORKFLOW_TOKEN }}
 
   post-prerelease:
     name: Post Prerelease Steps


### PR DESCRIPTION
The Release Workflow PR is not allowed to trigger required checks. To make sure the required checks are triggered we switch to RELEASE_WORKFLOW_TOKEN.