### PR TITLE
build(deps): bump the gradle-minor-dependencies group

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,7 +47,7 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation(project(":library"))
@@ -58,7 +58,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2")
     implementation("androidx.browser:browser:1.8.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
-    annotationProcessor("androidx.room:room-compiler:2.6.1")
+    annotationProcessor("androidx.room:room-compiler:2.7.1")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.9.1" apply false
+    id("com.android.application") version "8.9.2" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
-    id("com.android.library") version "8.9.1" apply false
+    id("com.android.library") version "8.9.2" apply false
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jetbrains.dokka") version "2.0.0"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -165,7 +165,7 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("com.google.androidbrowserhelper:androidbrowserhelper:2.6.0")
+    implementation("com.google.androidbrowserhelper:androidbrowserhelper:2.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.8.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
     implementation("net.openid:appauth:0.11.1")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -163,9 +163,9 @@ signing {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.15.0")
+    implementation("androidx.core:core-ktx:1.16.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("com.google.androidbrowserhelper:androidbrowserhelper:2.5.0")
+    implementation("com.google.androidbrowserhelper:androidbrowserhelper:2.6.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-cbor:1.8.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
     implementation("net.openid:appauth:0.11.1")


### PR DESCRIPTION
Bumps the gradle-minor-dependencies group with 4 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| com.android.application | `8.9.1` | `8.9.2` |
| com.android.library | `8.9.1` | `8.9.2` |
| androidx.core:core-ktx | `1.15.0` | `1.16.0` |
| androidx.room:room-compiler | `2.6.1` | `2.7.1` |

This merges https://github.com/FusionAuth/fusionauth-android-sdk/pull/196 without bumping `com.google.androidbrowserhelper:androidbrowserhelper` to 2.6.0