### PR TITLE
ci: pin 3rd party actions

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -65,7 +65,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Detekt
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -65,7 +65,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Detekt
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-latest.yml
@@ -72,7 +72,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
+++ b/.github/workflows/e2e-test-fusionauth-latest-android-matrix.yml
@@ -91,7 +91,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
@@ -71,7 +71,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
+++ b/.github/workflows/e2e-test-fusionauth-matrix-android-latest.yml
@@ -71,7 +71,7 @@ jobs:
 
       # Performs E2E Test using android-emulator-runner
       - name: run tests
-        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed #v2.34.0
+        uses: reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -59,7 +59,7 @@ jobs:
       
       # Sets up Gradle as a prerequisite to run Android Lint
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
         with:
           gradle-home-cache-cleanup: true
       
@@ -105,7 +105,7 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@v1.3.0
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -116,7 +116,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Android Lint
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -59,7 +59,7 @@ jobs:
       
       # Sets up Gradle as a prerequisite to run Android Lint
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-home-cache-cleanup: true
       
@@ -105,7 +105,7 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
@@ -116,7 +116,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Android Lint
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -40,14 +40,14 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
 
       # Performs analysis using MobSF and outputs a Sarif Report
       - name: Run mobsfscan
-        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 #0.4.5
+        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 # 0.4.5
         with:
           args: . --sarif --output mobsf.sarif.json || true
 

--- a/.github/workflows/mobsf.yml
+++ b/.github/workflows/mobsf.yml
@@ -40,14 +40,14 @@ jobs:
 
       # Sets up the reviewdog cli
       - name: Setup reviewdog
-        uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 #v1.3.2
 
       - name: Show reviewdog version
         run: reviewdog -version
 
       # Performs analysis using MobSF and outputs a Sarif Report
       - name: Run mobsfscan
-        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353
+        uses: MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 #0.4.5
         with:
           args: . --sarif --output mobsf.sarif.json || true
 

--- a/.github/workflows/prerelease-publish-local.yml
+++ b/.github/workflows/prerelease-publish-local.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Maven Pre-Release
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/prerelease-publish-local.yml
+++ b/.github/workflows/prerelease-publish-local.yml
@@ -54,7 +54,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Maven Pre-Release
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/release-publish-ossrh.yml
+++ b/.github/workflows/release-publish-ossrh.yml
@@ -30,7 +30,7 @@ jobs:
       repository_id: ${{ steps.create.outputs.repository_id }}
     steps:
       - id: create
-        uses: nexus-actions/create-nexus-staging-repo@main
+        uses: nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe #v1.3.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Maven Release
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4.3.0
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
         with:
           gradle-home-cache-cleanup: true
 
@@ -100,14 +100,14 @@ jobs:
     steps:
       - name: Discard
         if: ${{ needs.publish.result != 'success' }}
-        uses: nexus-actions/drop-nexus-staging-repo@main
+        uses: nexus-actions/drop-nexus-staging-repo@c27212525c2a475b7f87728fefd2f899002183fa #v1.1.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}
           staging_repository_id: ${{ needs.create_staging_repository.outputs.repository_id }}
       - name: Release
         if: ${{ needs.publish.result == 'success' }}
-        uses: nexus-actions/release-nexus-staging-repo@main
+        uses: nexus-actions/release-nexus-staging-repo@6632a81bfab63557b2717e8423b0a620ae5aa414 #v1.3.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}

--- a/.github/workflows/release-publish-ossrh.yml
+++ b/.github/workflows/release-publish-ossrh.yml
@@ -30,7 +30,7 @@ jobs:
       repository_id: ${{ steps.create.outputs.repository_id }}
     steps:
       - id: create
-        uses: nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe #v1.3.0
+        uses: nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe # v1.3.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
 
       # Sets up Gradle as a prerequisite to run Maven Release
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 #v4.3.1
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
         with:
           gradle-home-cache-cleanup: true
 
@@ -100,14 +100,14 @@ jobs:
     steps:
       - name: Discard
         if: ${{ needs.publish.result != 'success' }}
-        uses: nexus-actions/drop-nexus-staging-repo@c27212525c2a475b7f87728fefd2f899002183fa #v1.1.0
+        uses: nexus-actions/drop-nexus-staging-repo@c27212525c2a475b7f87728fefd2f899002183fa # v1.1.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}
           staging_repository_id: ${{ needs.create_staging_repository.outputs.repository_id }}
       - name: Release
         if: ${{ needs.publish.result == 'success' }}
-        uses: nexus-actions/release-nexus-staging-repo@6632a81bfab63557b2717e8423b0a620ae5aa414 #v1.3.0
+        uses: nexus-actions/release-nexus-staging-repo@6632a81bfab63557b2717e8423b0a620ae5aa414 # v1.3.0
         with:
           username: ${{ secrets.NXRM_TOKEN_USERNAME }}
           password: ${{ secrets.NXRM_TOKEN_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: release
         name: Run prerelease release-please
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
         with:
           config-file: ".github/prerelease-config.json"
           manifest-file: ".github/prerelease-manifest.json"
@@ -104,7 +104,7 @@ jobs:
           gh workflow run prerelease-publish-local.yml --ref refs/tags/$PRERELEASE_TAG
 
       - name: Run release release-please
-        uses: googleapis/release-please-action@v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
         with:
           config-file: ".github/release-config.json"
           manifest-file: ".github/release-manifest.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - id: release
         name: Run prerelease release-please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: ".github/prerelease-config.json"
           manifest-file: ".github/prerelease-manifest.json"
@@ -104,7 +104,7 @@ jobs:
           gh workflow run prerelease-publish-local.yml --ref refs/tags/$PRERELEASE_TAG
 
       - name: Run release release-please
-        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 #v4.2.0
+        uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
         with:
           config-file: ".github/release-config.json"
           manifest-file: ".github/release-manifest.json"


### PR DESCRIPTION
This pull request pins the versions of several 3rd party GitHub Actions used in the repository's workflows. The changes include updates to the `reviewdog`, `MobSF`, `release-please`, `gradle`, `android-emulator-runner` and `nexus-actions` actions.

### Affected Actions:

googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4.3.1
MobSF/mobsfscan@3d87bc570c4614d705547bddb521395663dba353 # 0.4.5
nexus-actions/create-nexus-staging-repo@990063f02160c633c168037b8b3e8585c76469fe # v1.3.0
nexus-actions/drop-nexus-staging-repo@c27212525c2a475b7f87728fefd2f899002183fa # v1.1.0
nexus-actions/release-nexus-staging-repo@6632a81bfab63557b2717e8423b0a620ae5aa414 # v1.3.0
reactivecircus/android-emulator-runner@1dcd0090116d15e7c562f8db72807de5e036a4ed # v2.34.0
reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
