### PR TITLE
fix: ActivityNotFound exception when no browser is found

### DIFF
--- a/app/src/androidTest/java/io/fusionauth/sdk/FullEnd2EndTest.kt
+++ b/app/src/androidTest/java/io/fusionauth/sdk/FullEnd2EndTest.kt
@@ -17,6 +17,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import io.fusionauth.mobilesdk.AuthorizationManager
 import kotlinx.coroutines.runBlocking
+import org.hamcrest.Matchers.not
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -123,6 +124,66 @@ internal class FullEnd2EndTest {
 
         logout()
     }
+
+    @Test
+    fun e2eTestNoBrowserAvailable() {
+        val disabled = disableAllBrowsers()
+        try {
+            // The test only makes sense if we actually removed every https handler.
+            check(!hasHttpsHandler()) {
+                "Could not disable all browsers on this device; cannot validate no-browser path"
+            }
+
+            // Trigger auth from the activity.
+            onView(withId(R.id.start_auth)).perform(click())
+
+            // Verify the friendly no-browser message is shown and Retry is hidden.
+            val expected = InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getString(R.string.no_browser_available)
+            device.wait(Until.findObject(By.text(expected)), TIMEOUT_MILLIS)
+            onView(withText(expected)).check(matches(isDisplayed()))
+            onView(withId(R.id.retry)).check(matches(not(isDisplayed())))
+        } finally {
+            enablePackages(disabled)
+        }
+    }
+
+    /**
+     * Disables every package that currently handles `https` VIEW intents for user 0 and
+     * returns the list so it can be re-enabled in teardown.
+     */
+    private fun disableAllBrowsers(): List<String> {
+        val handlers = httpsHandlerPackages()
+        logger.info("Disabling browser packages: $handlers")
+        handlers.forEach { pkg ->
+            device.executeShellCommand("pm disable-user --user 0 $pkg")
+        }
+        // Allow PackageManager state to settle.
+        Thread.sleep(500)
+        return handlers
+    }
+
+    private fun enablePackages(packages: List<String>) {
+        packages.forEach { pkg ->
+            logger.info("Re-enabling package: $pkg")
+            device.executeShellCommand("pm enable $pkg")
+        }
+    }
+
+    private fun httpsHandlerPackages(): List<String> {
+        val pm = InstrumentationRegistry.getInstrumentation().targetContext.packageManager
+        val intent = android.content.Intent(
+            android.content.Intent.ACTION_VIEW,
+            android.net.Uri.parse("https://example.com")
+        )
+        @Suppress("DEPRECATION")
+        return pm.queryIntentActivities(intent, 0)
+            .map { it.activityInfo.packageName }
+            .distinct()
+    }
+
+    private fun hasHttpsHandler(): Boolean = httpsHandlerPackages().isNotEmpty()
 
     // Helper Functions
 

--- a/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
+++ b/app/src/main/java/io/fusionauth/sdk/LoginActivity.kt
@@ -26,6 +26,7 @@ import io.fusionauth.mobilesdk.AuthorizationConfiguration
 import io.fusionauth.mobilesdk.AuthorizationManager
 import io.fusionauth.mobilesdk.oauth.OAuthAuthorizeOptions
 import io.fusionauth.mobilesdk.exceptions.AuthorizationException
+import io.fusionauth.mobilesdk.exceptions.BrowserNotAvailableException
 import io.fusionauth.mobilesdk.storage.DataStoreStorage
 import kotlinx.coroutines.launch
 
@@ -98,6 +99,9 @@ class LoginActivity : AppCompatActivity() {
                             prompt = prompt
                         )
                     )
+            } catch (e: BrowserNotAvailableException) {
+                Log.e(TAG, "No browser available to perform authorization", e)
+                displayError(getString(R.string.no_browser_available), false)
             } catch (e: AuthorizationException) {
                 Log.e(TAG, "Error while authorizing", e)
                 displayError(e.message ?: "Error while authorizing", true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="active_configuration">Active Configuration</string>
     <string name="your_balance_is">Your balance is:</string>
     <string name="tenant_label">Tenant: </string>
+    <string name="no_browser_available">No web browser is available on this device. Please install a browser (such as Chrome) and try again.</string>
 </resources>

--- a/library/src/main/java/io/fusionauth/mobilesdk/exceptions/AuthorizationException.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/exceptions/AuthorizationException.kt
@@ -1,6 +1,6 @@
 package io.fusionauth.mobilesdk.exceptions
 
-class AuthorizationException: Exception {
+open class AuthorizationException: Exception {
 
     constructor(message: String): super(message)
 

--- a/library/src/main/java/io/fusionauth/mobilesdk/exceptions/BrowserNotAvailableException.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/exceptions/BrowserNotAvailableException.kt
@@ -1,0 +1,20 @@
+package io.fusionauth.mobilesdk.exceptions
+
+/**
+ * Thrown when an OAuth authorization or end-session flow cannot be launched because the device
+ * has no browser (or no Custom Tabs / browser activity) capable of handling the request.
+ *
+ * This typically wraps an [android.content.ActivityNotFoundException] raised by the underlying
+ * AppAuth call when no `android.intent.action.VIEW` handler for `https` is available.
+ *
+ * Consumers should catch this exception (or [AuthorizationException]) and surface a recoverable
+ * error to the user — for example, prompting them to install a browser.
+ */
+class BrowserNotAvailableException : AuthorizationException {
+
+    constructor(message: String) : super(message)
+
+    constructor(message: String, cause: Throwable) : super(message, cause)
+
+    constructor(cause: Throwable) : super(cause)
+}

--- a/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
+++ b/library/src/main/java/io/fusionauth/mobilesdk/oauth/OAuthAuthorizationService.kt
@@ -1,6 +1,7 @@
 package io.fusionauth.mobilesdk.oauth
 
 import android.app.PendingIntent
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -11,6 +12,7 @@ import io.fusionauth.mobilesdk.SingletonUnsecureConnectionBuilder
 import io.fusionauth.mobilesdk.TokenManager
 import io.fusionauth.mobilesdk.UserInfo
 import io.fusionauth.mobilesdk.exceptions.AuthorizationException
+import io.fusionauth.mobilesdk.exceptions.BrowserNotAvailableException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -133,27 +135,34 @@ class OAuthAuthorizationService internal constructor(
         val authRequest = authRequestBuilder.build()
 
         val authService = getAuthorizationService()
-        if (options?.cancelIntent == null) {
+        try {
+            if (options?.cancelIntent == null) {
+                authService.performAuthorizationRequest(
+                    authRequest,
+                    completedPendingIntent,
+                )
+                return
+            }
             authService.performAuthorizationRequest(
                 authRequest,
                 completedPendingIntent,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    options.cancelIntent.also {
+                        replaceExtras(it, Bundle().also { bundle ->
+                            bundle.putBoolean(EXTRA_CANCELLED, true)
+                        })
+                    },
+                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                ),
             )
-            return
+        } catch (e: ActivityNotFoundException) {
+            throw BrowserNotAvailableException(
+                "No browser is available to perform the authorization request",
+                e
+            )
         }
-        authService.performAuthorizationRequest(
-            authRequest,
-            completedPendingIntent,
-            PendingIntent.getActivity(
-                context,
-                0,
-                options.cancelIntent.also {
-                    replaceExtras(it, Bundle().also { bundle ->
-                        bundle.putBoolean(EXTRA_CANCELLED, true)
-                    })
-                },
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            ),
-        )
     }
 
     /**
@@ -314,27 +323,34 @@ class OAuthAuthorizationService internal constructor(
         val logoutRequest = logoutRequestBuilder.build()
 
         val authService = getAuthorizationService()
-        if (options?.cancelIntent == null) {
+        try {
+            if (options?.cancelIntent == null) {
+                authService.performEndSessionRequest(
+                    logoutRequest,
+                    completedPendingIntent,
+                )
+                return
+            }
             authService.performEndSessionRequest(
                 logoutRequest,
                 completedPendingIntent,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    options.cancelIntent.also {
+                        replaceExtras(it, Bundle().also { bundle ->
+                            bundle.putBoolean(EXTRA_CANCELLED, true)
+                        })
+                    },
+                    PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+                ),
             )
-            return
+        } catch (e: ActivityNotFoundException) {
+            throw BrowserNotAvailableException(
+                "No browser is available to perform the end session request",
+                e
+            )
         }
-        authService.performEndSessionRequest(
-            logoutRequest,
-            completedPendingIntent,
-            PendingIntent.getActivity(
-                context,
-                0,
-                options.cancelIntent.also {
-                    replaceExtras(it, Bundle().also { bundle ->
-                        bundle.putBoolean(EXTRA_CANCELLED, true)
-                    })
-                },
-                PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
-            ),
-        )
     }
 
     /**


### PR DESCRIPTION
[Linear](https://linear.app/fusionauth/issue/SDK-43/bug-activitynotfoundexception-is-thrown-when-no-intent-can-handle-the)

Here's a video of the [No web browser is available...](https://github.com/user-attachments/assets/8a4a5084-28cd-4659-8859-480d7634d279) message being displayed on the ChangeBank Application.